### PR TITLE
Fixed from Demo comments

### DIFF
--- a/xpr_report/report/sale_order_xprima.rml
+++ b/xpr_report/report/sale_order_xprima.rml
@@ -273,7 +273,7 @@
             <para style="terp_default_9">[[line.product_id.default_code and ('[' + format(line.product_id.default_code) + ']') or '']] [[ line.product_id.name ]] [[line.product_id.attribute_value_ids and ("(" +  ", ".join([v.name for v in line.product_id.attribute_value_ids]) + ")") or '']]</para>
           </td>
           <td>
-            <para style="terp_default_9">[[ format(line.name) ]] </para>
+            <para style="terp_default_9">[[ line.solution_part  == 3 and 'Solution Price' or format(line.name) ]] </para>
           </td>
           <!--
           <td>

--- a/xpr_solution_builder/models.py
+++ b/xpr_solution_builder/models.py
@@ -255,7 +255,7 @@ class SalesOrder(models.Model):
         sequence = 0
         mandatory_products = list(order.solution.products) + [
             item.product for item in self.solution.options_extra
-            if item.sticky
+            if item.selected_default
         ]
 
         for product in mandatory_products:

--- a/xpr_solution_builder/views/sale_order.xml
+++ b/xpr_solution_builder/views/sale_order.xml
@@ -6,7 +6,7 @@
 
 			<field name="name">order</field>
 			<field name="model">sale.order</field>
-			<field name="inherit_id" ref="sale.view_order_form"/>
+			<field name="inherit_id" ref="sale_stock.view_order_form_inherit"/>
 			<field name="arch" type="xml">
 
 				<field name="client_order_ref" position="after">	
@@ -56,17 +56,17 @@
                                         <field name="invoice_lines"/>
                                     </div>
                         </form>
-                        <tree string="Sales Order Lines" create="false" delete="false">
+                        <tree string="Sales Order Lines" create="false" delete="false" editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="state" invisible="1"/>
                                     <field name="th_weight" invisible="1"/>
-                                    <field name="product_id" context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}" groups="base.group_user" on_change="product_id_change(parent.pricelist_id, product_id, product_uom_qty, False, product_uos_qty, False, name, parent.partner_id, False, True, parent.date_order, False, parent.fiscal_position, False, context)"/>
-                                    <field name="name"/>
-                                    <field name="product_uom_qty" context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}" on_change="product_id_change(parent.pricelist_id, product_id, product_uom_qty, product_uom, product_uos_qty, product_uos, name, parent.partner_id, False, False, parent.date_order, False, parent.fiscal_position, True, context)"/>
-                                    <field name="product_uom" on_change="product_uom_change(parent.pricelist_id, product_id, product_uom_qty, product_uom, product_uos_qty, product_uos, name, parent.partner_id, False, False, parent.date_order, context)" groups="product.group_uom" options="{&quot;no_open&quot;: True}"/>
+                                    <field name="product_id"  groups="base.group_user" readonly="1"/>
+                                    <field name="name" readonly="True"/>
+                                    <field name="product_uom_qty" readonly="1" />
+                                    <field name="product_uom" groups="product.group_uom" readonly="1" />
                                     <field name="product_uos_qty" groups="product.group_uos" invisible="1"/>
                                     <field name="product_uos" string="UoS" groups="product.group_uos" invisible="1"/>
-                                    <field name="price_unit"  />
+                                    <field name="price_unit" readonly="1" />
                                     
                                     <field name="tax_id" widget="many2many_tags" domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]" invisible="1"/>
                                     <field name="solution_part" invisible="1" />


### PR DESCRIPTION
Renamed report line for solution integration
Made sales order line readonly, except for discount.
Auto select items are added to sales order, not only the sticky ones.
